### PR TITLE
Support Null Bulk String response from server

### DIFF
--- a/lib/faktory/protocol.ex
+++ b/lib/faktory/protocol.ex
@@ -118,6 +118,8 @@ defmodule Faktory.Protocol do
     rx(conn, size)
   end
 
+  defp rx(conn, size) when size == -1, do: {:ok, nil}
+
   defp rx(conn, size) when size == 0 do
     case recv(conn, :line) do
       {:ok, _} -> {:ok, nil}


### PR DESCRIPTION
According to the RESP spec, if the server replies with `$-1\r\n` this
means `nil`. Added support for this response.