### PR TITLE
Handle process exits of workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Very similar to Sidekiq...
 defmodule FunWork do
   use Faktory.Job
 
-  faktory_options queue: "default", retries: 25, backtrace: 0
+  faktory_options queue: "default", retry: 25, backtrace: 0
 
   def perform(x, y) do
     IO.puts "#{x} is a fun number! ... #{y} is not... :("

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -29,7 +29,7 @@ defmodule Faktory do
   Ex:
   ```elixir
     push(MyFunWork, [queue: "somewhere"], [1, 2])
-    push("BoringWork", [retries: 0, backtrace: 10], [])
+    push("BoringWork", [retry: 0, backtrace: 10], [])
   ```
   """
   @spec push(atom | binary, Keyword.t, [term]) :: jid

--- a/lib/faktory/job.ex
+++ b/lib/faktory/job.ex
@@ -33,7 +33,7 @@ defmodule Faktory.Job do
   defmodule MyFunkyJob do
     use Faktory.Job
 
-    faktory_options queue: "default", retries: 25, backtrace: 0
+    faktory_options queue: "default", retry: 25, backtrace: 0
 
     # ...
   end
@@ -58,7 +58,7 @@ defmodule Faktory.Job do
   defmacro __using__(_options) do
     quote do
       import Faktory.Job, only: [faktory_options: 1]
-      @faktory_options [queue: "default", retries: 25, backtrace: 0, middleware: []]
+      @faktory_options [queue: "default", retry: 25, backtrace: 0, middleware: []]
       @before_compile Faktory.Job
 
       def perform_async(args) do
@@ -90,7 +90,7 @@ defmodule Faktory.Job do
   ## Options
 
     * `:queue` - Name of queue. Default `"default"`
-    * `:retries` - How many times to retry. Default `25`
+    * `:retry` - How many times to retry. Default `25`
     * `:backtrace` - How many lines of backtrace to store if the job errors. Default `0`
   """
   @spec faktory_options(Keyword.t) :: nil


### PR DESCRIPTION
It is possible that a worker will exit with EXIT signal if it spawns a
linked process, which dies. In order to handle this the parent of the
Executor should trap exits and handle EXIT messages.

Unfortunately there is no easy way to render stack traces in this
situation.

In the latest faktory spec the number of retries is specified with a
"retry" key, not "retries" as it used to be. Updated the code and the
documentation.