### PR TITLE
Dry up references to app name (take two)

### DIFF
--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -9,7 +9,7 @@ defmodule Faktory do
   # A connection to the Faktory server.
   @type conn :: pid
 
-  @app_name Application.get_application(__MODULE__)
+  @app_name Mix.Project.config[:app]
 
   alias Faktory.{Logger, Protocol, Utils, Configuration}
 

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -11,6 +11,9 @@ defmodule Faktory do
 
   @app_name Mix.Project.config[:app]
 
+  @doc false
+  def app_name, do: @app_name
+
   alias Faktory.{Logger, Protocol, Utils, Configuration}
 
   @doc false

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -9,6 +9,7 @@ defmodule Faktory do
   # A connection to the Faktory server.
   @type conn :: pid
 
+  # Retain this at compile time since Mix.* will not be available in release builds (e.g., exrm)
   @app_name Mix.Project.config[:app]
 
   @doc false

--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -222,7 +222,7 @@ defmodule Faktory.Configuration do
   end
 
   defp get_env(key) do
-    Application.get_env(:faktory_worker_ex, key)
+    Application.get_env(Faktory.app_name(), key)
     |> Utils.parse_config_value
   end
 


### PR DESCRIPTION
There is a problem with the approach I used in #6. The application isn't loaded at compile time, so `Application.get_application(__MODULE__)` would return `nil`. And since it was stored in a module attribute, the `nil` was retained and not reevaluated at run time. It still mostly worked because `nil` is a valid configuration key, but it broke the `mix faktory` task and was very confusing.

Instead, we can use `Mix.Project.config[:app]` which is available at compile time. I also DRY'd up a dangling reference to the bare app name.