### PR TITLE
Add TLS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # faktory_worker_ex changes
 
+0.3.1
+-----------
+* Update protocol to handle `$-1\r\n`
+
 0.3.0
 -----------
 * Configure with Mix Config and callback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # faktory_worker_ex changes
 
+0.4.0
+-----------
+* The `:retries` option was renamed to `:retry`.
+* Handle non-exception based errors (`{:EXIT, pid, :killed}`).
+* More tests and test specific "callbacks" to aid in testing.
+
 0.3.1
 -----------
 * Update protocol to handle `$-1\r\n`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ You should be able to go to [http://localhost:7420](http://localhost:7420) and s
 ## What's missing?
 
 * Authentication
-* TLS
 * Responding to the terminate signal (from the Faktory server)
 * Tests
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Very similar to Sidekiq...
 defmodule FunWork do
   use Faktory.Job
 
-  faktory_options queue: "default", retries: 25, backtrace: 0
+  faktory_options queue: "default", retry: 25, backtrace: 0
 
   def perform(x, y) do
     IO.puts "#{x} is a fun number! ... #{y} is not... :("

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,7 @@ use Mix.Config
 config :faktory_worker_ex,
   port: 7421,
   client: [pool: 5],
+  use_tls: false,
   workers: [
     default: [
       concurrency: 2

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -29,7 +29,7 @@ defmodule Faktory do
   Ex:
   ```elixir
     push(MyFunWork, [queue: "somewhere"], [1, 2])
-    push("BoringWork", [retries: 0, backtrace: 10], [])
+    push("BoringWork", [retry: 0, backtrace: 10], [])
   ```
   """
   @spec push(atom | binary, Keyword.t, [term]) :: jid

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -15,6 +15,8 @@ defmodule Faktory do
 
   alias Faktory.{Logger, Protocol, Utils, Configuration}
 
+  defdelegate env, to: Utils
+
   @doc false
   def start_workers? do
     !!get_env(:start_workers)
@@ -35,6 +37,7 @@ defmodule Faktory do
   @spec push(atom | binary, Keyword.t, [term]) :: jid
   def push(module, args, options \\ []) do
     import Faktory.Utils, only: [new_jid: 0]
+    import Faktory.TestHelp, only: [if_test: 1]
 
     module = Module.safe_concat([module])
     options = Keyword.merge(module.faktory_options, options)
@@ -54,7 +57,7 @@ defmodule Faktory do
 
     # To facilitate testing, we keep a map if jid -> pid and send messages to
     # the pid at various points in the job's lifecycle.
-    if Mix.env == :test do
+    if_test do
       TestJidPidMap.register(job["jid"])
     end
 

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -52,6 +52,12 @@ defmodule Faktory do
       middleware -> middleware
     end
 
+    # To facilitate testing, we keep a map if jid -> pid and send messages to
+    # the pid at various points in the job's lifecycle.
+    if Mix.env == :test do
+      TestJidPidMap.register(job["jid"])
+    end
+
     traverse_middleware(job, middleware)
 
     %{ "jid" => jid, "args" => args } = job

--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -125,6 +125,7 @@ defmodule Faktory.Configuration do
     config = config
       |> put_from_env(:host, :host)
       |> put_from_env(:port, :port)
+      |> put_from_env(:use_tls, :use_tls)
       |> put_from_env(:fn, :config_fn)
       |> Keyword.put(:name, name)
 

--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -129,6 +129,14 @@ defmodule Faktory.Configuration do
       |> put_from_env(:fn, :config_fn)
       |> Keyword.put(:name, name)
 
+    # TODO: Support the rest of the CLI options
+    cli_options = Application.get_env(:faktory_worker_ex, :cli_options)
+    config = if use_tls = cli_options[:use_tls] do
+      config ++ [use_tls: use_tls]
+    else
+      config
+    end
+
     # Convert to struct.
     config = struct!(type, config)
 

--- a/lib/faktory/configuration/client.ex
+++ b/lib/faktory/configuration/client.ex
@@ -3,7 +3,7 @@ defmodule Faktory.Configuration.Client do
 
   defstruct [
     host: "localhost", port: 7419, pool: 10, middleware: [], fn: nil,
-    name: "default", wid: nil
+    name: "default", wid: nil, use_tls: false
   ]
 
 end

--- a/lib/faktory/configuration/worker.ex
+++ b/lib/faktory/configuration/worker.ex
@@ -3,7 +3,7 @@ defmodule Faktory.Configuration.Worker do
 
   defstruct [
     host: "localhost", port: 7419, pool: nil, middleware: [], fn: nil,
-    name: "default", concurrency: 20, wid: nil, queues: ["default"]
+    name: "default", concurrency: 20, wid: nil, queues: ["default"], use_tls: false
   ]
 
 end

--- a/lib/faktory/connection.ex
+++ b/lib/faktory/connection.ex
@@ -31,11 +31,13 @@ defmodule Faktory.Connection do
     host = String.to_charlist(host)
     transport = if use_tls, do: :ssl, else: :gen_tcp
 
+    certs = :certifi.cacerts()
+
     base_opts = [:binary, active: false]
     tcp_opts = if use_tls do
       # Disable TLS verification in dev/test so that self-signed certs will work
       verify_opts = if Mix.env in [:dev, :test], do: [verify: :verify_none], else: [verify: :verify_peer]
-      base_opts ++ verify_opts ++ [versions: [:'tlsv1.2']]
+      base_opts ++ verify_opts ++ [versions: [:'tlsv1.2'], depth: 99, cacerts: certs]
     else
       base_opts
     end

--- a/lib/faktory/job.ex
+++ b/lib/faktory/job.ex
@@ -33,7 +33,7 @@ defmodule Faktory.Job do
   defmodule MyFunkyJob do
     use Faktory.Job
 
-    faktory_options queue: "default", retries: 25, backtrace: 0
+    faktory_options queue: "default", retry: 25, backtrace: 0
 
     # ...
   end
@@ -58,7 +58,7 @@ defmodule Faktory.Job do
   defmacro __using__(_options) do
     quote do
       import Faktory.Job, only: [faktory_options: 1]
-      @faktory_options [queue: "default", retries: 25, backtrace: 0, middleware: []]
+      @faktory_options [queue: "default", retry: 25, backtrace: 0, middleware: []]
       @before_compile Faktory.Job
 
       def perform_async(args) do
@@ -90,7 +90,7 @@ defmodule Faktory.Job do
   ## Options
 
     * `:queue` - Name of queue. Default `"default"`
-    * `:retries` - How many times to retry. Default `25`
+    * `:retry` - How many times to retry. Default `25`
     * `:backtrace` - How many lines of backtrace to store if the job errors. Default `0`
   """
   @spec faktory_options(Keyword.t) :: nil

--- a/lib/faktory/tasks/faktory.ex
+++ b/lib/faktory/tasks/faktory.ex
@@ -21,8 +21,8 @@ defmodule Mix.Tasks.Faktory do
   @doc false
   def run(args) do
     OptionParser.parse(args,
-      strict: [concurrency: :integer, queues: :string, pool: :integer],
-      aliases: [c: :concurrency, q: :queues, p: :pool]
+      strict: [concurrency: :integer, queues: :string, pool: :integer, use_tls: :boolean],
+      aliases: [c: :concurrency, q: :queues, p: :pool, t: :use_tls, tls: :use_tls]
     ) |> case do
       {options, [], []} -> start(options)
       _ ->
@@ -51,6 +51,7 @@ defmodule Mix.Tasks.Faktory do
     -c, --concurrency  Number of worker processes
     -q, --queues       Comma seperated list of queues
     -p, --pool         Connection pool size. Default: <concurrency>
+    -t, --tls          Enable TLS when connecting to Faktory server. Default: disable TLS
     """
   end
 

--- a/lib/faktory/test_help.ex
+++ b/lib/faktory/test_help.ex
@@ -1,0 +1,9 @@
+defmodule Faktory.TestHelp do
+
+  defmacro if_test(do: block) do
+    if Faktory.Utils.env == :test do
+      quote do: unquote(block)
+    end
+  end
+
+end

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -68,4 +68,13 @@ defmodule Faktory.Utils do
     :os.system_time(:milli_seconds)
   end
 
+  def env do
+    cond do
+      function_exported?(Mix, :env, 1) -> Mix.env
+      Application.get_env(@app_name, :env) != nil -> Application.get_env(@app_name, :env)
+      Map.has_key?(System.get_env, "MIX_ENV") -> System.get_env("MIX_ENV")
+      true -> :dev
+    end
+  end
+
 end

--- a/lib/faktory/worker.ex
+++ b/lib/faktory/worker.ex
@@ -4,6 +4,7 @@ defmodule Faktory.Worker do
 
   alias Faktory.{Logger, Protocol, Executor}
   import Faktory.Utils, only: [now_in_ms: 0]
+  import Faktory.TestHelp, only: [if_test: 1]
 
   def start_link(config) do
     GenServer.start_link(__MODULE__, config)
@@ -110,7 +111,7 @@ defmodule Faktory.Worker do
     {:ok, _} = with_conn(state, &Protocol.ack(&1, jid))
     Logger.debug("ack'ed #{jid}")
 
-    if Mix.env == :test do
+    if_test do
       send TestJidPidMap.get(jid), {:report_ack, %{job: job, time: time}}
     end
   end
@@ -127,7 +128,7 @@ defmodule Faktory.Worker do
     {:ok, _} = with_conn(state, &Protocol.fail(&1, jid, errtype, message, trace))
     Logger.debug("fail'ed #{jid}")
 
-    if Mix.env == :test do
+    if_test do
       send TestJidPidMap.get(jid), {:report_fail, %{job: job, time: time, error: error}}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule Faktory.Mixfile do
       {:poison, "~> 3.1"},
       {:poolboy, "~> 1.5"},
       {:ex_doc, "~> 0.18.1", only: :dev},
+      {:certifi, "~> 2.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Faktory.Mixfile do
   def project do
     [
       app: :faktory_worker_ex,
-      version: "0.3.1",
+      version: "0.4.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Faktory.Mixfile do
   def project do
     [
       app: :faktory_worker_ex,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+%{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [], [], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},

--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -3,11 +3,15 @@ defmodule BasicTest do
 
   setup do
     Stack.clear
+    
+    :ok
   end
 
   test "enqueing and processing a job" do
-    AddWorker.perform_async([PidMap.register, 1, 2])
+    job = AddWorker.perform_async([PidMap.register, 1, 2])
+    jid = job["jid"]
 
+    assert_receive {:report_ack, %{job: %{"jid" => ^jid}}}
     assert_receive {:add_result, 3}
   end
 
@@ -27,6 +31,22 @@ defmodule BasicTest do
     )
 
     assert_receive {:add_result, 5}
+  end
+
+  test "worker handles exceptions" do
+    job = AddWorker.perform_async([PidMap.register, 1, "foo"])
+    jid = job["jid"]
+
+    assert_receive {:report_fail, %{job: %{"jid" => ^jid}, error: error}}
+    assert {"ArithmeticError", _, _} = error
+  end
+
+  test "worker handles {:EXIT, pid, :KILLED}" do
+    job = DieWorker.perform_async([true])
+    jid = job["jid"]
+
+    assert_receive {:report_fail, %{job: %{"jid" => ^jid}, error: error}}
+    assert {"killed", _, _} = error
   end
 
 end

--- a/test/support/die_worker.ex
+++ b/test/support/die_worker.ex
@@ -1,0 +1,11 @@
+defmodule DieWorker do
+  use Faktory.Job
+
+  def perform(die) do
+    if die do
+      Process.exit(self(), :kill)
+    else
+      "Didn't die!"
+    end
+  end
+end

--- a/test/support/test_jid_pid_map.ex
+++ b/test/support/test_jid_pid_map.ex
@@ -1,0 +1,16 @@
+defmodule TestJidPidMap do
+
+  def start_link do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  def register(jid) do
+    pid = self()
+    Agent.update(__MODULE__, &Map.put(&1, jid, pid))
+  end
+
+  def get(jid) do
+    Agent.get(__MODULE__, & &1[jid])
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,7 @@
 Faktory.flush
 {:ok, _} = PidMap.start_link
 {:ok, _} = Stack.start_link
+{:ok, _} = TestJidPidMap.start_link
 Faktory.Configuration.fetch_all(:worker) |> Enum.each(fn config ->
   {:ok, _} = Faktory.Supervisor.Workers.start_link(config)
 end)


### PR DESCRIPTION
This adds support for connecting to a TLS-protected Faktory server. It validates server certificates in production mode but not dev/test. The CLI option handling for `mix faktory` is a bit broken/messy and is something I'll work on in a subsequent PR.

I developed a simple Docker image that makes TLS testing easy, but imo it would be better suited for the main Faktory repo than this one — each client library could use it.

```$ docker run --rm -it -p 7419-7420:7419-7420/tcp acjensen/faktory-tls:latest```

Depends on #8.