### PR TITLE
Treat compile warnings as errors

### DIFF
--- a/lib/faktory/protocol.ex
+++ b/lib/faktory/protocol.ex
@@ -118,7 +118,7 @@ defmodule Faktory.Protocol do
     rx(conn, size)
   end
 
-  defp rx(conn, size) when size == -1, do: {:ok, nil}
+  defp rx(_conn, size) when size == -1, do: {:ok, nil}
 
   defp rx(conn, size) when size == 0 do
     case recv(conn, :line) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Faktory.Mixfile do
       elixir: "~> 1.5",
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env),
+      aliases: aliases(),
 
       # Hex
       description: "Elixir worker for Faktory",
@@ -51,5 +52,11 @@ defmodule Faktory.Mixfile do
 
   defp elixirc_paths(_) do
     ["lib"]
+  end
+
+  defp aliases do
+    [
+      "compile": ["compile --warnings-as-errors"]
+    ]
   end
 end

--- a/test/support/stack.ex
+++ b/test/support/stack.ex
@@ -8,7 +8,7 @@ defmodule Stack do
     Agent.update(__MODULE__, &[item | &1])
   end
 
-  def pop(item) do
+  def pop do
     Agent.get_and_update(__MODULE__, fn [item | list] -> {item, list} end)
   end
 


### PR DESCRIPTION
This should help to avoid silly bugs like the recent [@app_name](https://github.com/cjbottaro/faktory_worker_ex/pull/5#discussion_r159017525) issue.

EDIT: Created this on the wrong repo. Will fix.
  